### PR TITLE
Disable ctest on OSX and add functional test of ldas_analysis_ready

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -19,8 +19,8 @@ cmake \
 # build
 cmake --build . --parallel ${CPU_COUNT} --verbose
 
-# test
-if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" || "${CROSSCOMPILING_EMULATOR}" != "" ]]; then
+# test (flaky on osx-64)
+if [[ "${target_platform}" == "linux-64" ]]; then
 	ctest --parallel ${CPU_COUNT} --verbose
 fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
 build:
   error_overdepending: true
   error_overlinking: true
-  number: 0
+  number: 1
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage("ldas-tools-frameapi", max_pin="x.x") }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,8 +44,12 @@ test:
   requires:
     - pkg-config  # [unix]
   commands:
+    # generate fake data
+    - framecpp_sample
+    # generate analysis-ready segments
+    - ldas_analysis_ready --frame-file-pattern "*.gwf" --ifo Z0 --analysis-ready-channel RAMPED_INT_8U_1
+    # sanity check headers and pkg-config
     - test -d ${PREFIX}/include/frameAPI  # [unix]
-    - test -f ${PREFIX}/lib/libldasframe${SHLIB_EXT}  # [unix]
     - pkg-config --print-errors --exact-version {{ version }} ldastools-ldasframe  # [unix]
 
 about:


### PR DESCRIPTION
The ctest suite seems flaky, so this PR disables it on all target platforms _except_ `linux-64`. In place I have added a functional test of `ldas_analysis_ready` which is hopefully good enough to smoke out any egregious problems.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
